### PR TITLE
Fix metrics test equity series generation

### DIFF
--- a/PaperTrader Lab/tests/test_metrics.py
+++ b/PaperTrader Lab/tests/test_metrics.py
@@ -3,6 +3,11 @@ from backtest.metrics import equity_to_metrics
 
 def test_equity_metrics_basic():
     idx = pd.date_range("2024-01-01", periods=10, freq="D")
-    equity = pd.Series(100000 * (1 + 0.001) ** range(10), index=idx)
+    # Generate an equity curve with a small daily gain.
+    # range objects cannot be used directly as an exponent with a float,
+    # so compute each step explicitly.
+    equity = pd.Series(
+        [100000 * (1 + 0.001) ** i for i in range(10)], index=idx
+    )
     m = equity_to_metrics(equity)
     assert "CAGR" in m and m["CAGR"] is not None


### PR DESCRIPTION
## Summary
- Correct equity curve generation in metrics test to avoid exponentiation TypeError
- Add clarifying comments

## Testing
- `PYTHONPATH="PaperTrader Lab" pytest "PaperTrader Lab/tests" -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f3547834832db1ec1b1a1f3ea3bc