### PR TITLE
Add basic price direction ML module

### DIFF
--- a/PaperTrader Lab/ml/__init__.py
+++ b/PaperTrader Lab/ml/__init__.py
@@ -1,0 +1,5 @@
+"""Machine learning utilities for PaperTrader Lab."""
+
+from .direction import train_direction_model, predict_direction
+
+__all__ = ["train_direction_model", "predict_direction"]

--- a/PaperTrader Lab/ml/direction.py
+++ b/PaperTrader Lab/ml/direction.py
@@ -1,0 +1,57 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
+
+
+def _build_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Generate basic technical features from price data.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Must contain a ``close`` column with prices indexed by date.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame of engineered features with NaN rows dropped.
+    """
+    feats = pd.DataFrame(index=df.index)
+    feats["return_1"] = df["close"].pct_change()
+    feats["return_5"] = df["close"].pct_change(5)
+    return feats.dropna()
+
+
+def train_direction_model(df: pd.DataFrame) -> Pipeline:
+    """Train a simple logistic regression to predict price direction.
+
+    The model predicts whether the next ``close`` price will be higher than
+    the current ``close`` based on past percentage returns.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Price data with a ``close`` column.
+
+    Returns
+    -------
+    sklearn.pipeline.Pipeline
+        Trained scikit-learn pipeline with scaling and logistic regression.
+    """
+    X = _build_features(df)
+    # Target: 1 if next close is higher, else 0
+    y = (df["close"].shift(-1) > df["close"]).astype(int).loc[X.index]
+    model = Pipeline([
+        ("scaler", StandardScaler()),
+        ("lr", LogisticRegression(solver="liblinear")),
+    ])
+    model.fit(X, y)
+    return model
+
+
+def predict_direction(model: Pipeline, df: pd.DataFrame) -> pd.Series:
+    """Predict upward (1) or downward (0) movement using a trained model."""
+    X = _build_features(df)
+    preds = model.predict(X)
+    return pd.Series(preds, index=X.index, name="direction")

--- a/PaperTrader Lab/requirements.txt
+++ b/PaperTrader Lab/requirements.txt
@@ -1,6 +1,7 @@
 streamlit>=1.36
 pandas>=2.2
 numpy>=1.26
+scikit-learn>=1.4
 plotly>=5.22
 python-dotenv>=1.0
 tenacity>=8.3

--- a/PaperTrader Lab/tests/test_ml_direction.py
+++ b/PaperTrader Lab/tests/test_ml_direction.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import numpy as np
+from ml import train_direction_model, predict_direction
+
+
+def test_train_and_predict_direction():
+    dates = pd.date_range("2024-01-01", periods=60, freq="D")
+    # synthetic price data with trend and noise
+    prices = 100 + np.linspace(0, 5, len(dates)) + np.sin(np.linspace(0, 6, len(dates)))
+    df = pd.DataFrame({"close": prices}, index=dates)
+    model = train_direction_model(df)
+    preds = predict_direction(model, df)
+    # predictions should cover available feature rows and be binary
+    assert set(preds.unique()) <= {0, 1}
+    assert len(preds) == len(df) - 5  # due to lookback in feature engineering

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - Parametri strategia.
 - **Metriche**: CAGR, Sharpe/Sortino, Max Drawdown, Calmar, ecc.
 - **Caching** dei dati per velocizzare le prove.
+- Semplice modulo di machine learning per prevedere la direzione del prezzo.
 
 ---
 


### PR DESCRIPTION
## Summary
- add logistic regression based direction predictor under `ml`
- document ML module in README and expose helper functions
- include scikit-learn dependency and tests for model training

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a06ffe078832d82b5cc64c7fce425