### PR TITLE
Support custom Alpaca endpoints

### DIFF
--- a/PaperTrader Lab/paper/alpaca.py
+++ b/PaperTrader Lab/paper/alpaca.py
@@ -7,7 +7,12 @@ def _trading_client():
     from alpaca.trading.client import TradingClient
     if not SETTINGS.alpaca_api_key or not SETTINGS.alpaca_secret_key:
         raise ProviderError("Missing Alpaca API keys")
-    return TradingClient(SETTINGS.alpaca_api_key, SETTINGS.alpaca_secret_key, paper=True)
+    return TradingClient(
+        SETTINGS.alpaca_api_key,
+        SETTINGS.alpaca_secret_key,
+        paper="paper" in SETTINGS.alpaca_base_url,
+        url_override=SETTINGS.alpaca_base_url,
+    )
 
 def account():
     tc = _trading_client()

--- a/PaperTrader Lab/tests/test_credentials.py
+++ b/PaperTrader Lab/tests/test_credentials.py
@@ -31,8 +31,10 @@ def test_test_alpaca_credentials(monkeypatch):
         def get_account(self):
             return True
 
-    def fake_client(key, secret, base_url=None):
+    def fake_client(key, secret, paper=None, url_override=None):
         assert key == "k" and secret == "s"
+        assert paper is True
+        assert url_override == "https://paper-api.alpaca.markets"
         return DummyClient()
 
     monkeypatch.setattr("alpaca.trading.client.TradingClient", fake_client)

--- a/PaperTrader Lab/utils/config.py
+++ b/PaperTrader Lab/utils/config.py
@@ -65,7 +65,12 @@ def test_alpaca_credentials(key: str, secret: str, base_url: str) -> Tuple[bool,
     try:
         from alpaca.trading.client import TradingClient
 
-        client = TradingClient(key, secret, base_url=base_url)
+        client = TradingClient(
+            key,
+            secret,
+            paper="paper" in base_url,
+            url_override=base_url,
+        )
         client.get_account()
         return True, ""
     except Exception as e:  # pragma: no cover - network errors mocked nei test


### PR DESCRIPTION
## Summary
- allow overriding Alpaca base URL and choose paper mode based on the URL
- propagate custom base URL to paper trading client
- update credential tests for new TradingClient arguments

## Testing
- `PYTHONPATH='PaperTrader Lab' pytest 'PaperTrader Lab/tests/test_credentials.py'`


------
https://chatgpt.com/codex/tasks/task_e_689aefa79738832da43924daad31f034