### PR TITLE
refactor credential management with provider plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,20 @@
+ENABLE_ALPACA=true
+ENABLE_OANDA=false
+ENABLE_BINANCE=false
+DEFAULT_DATA_PROVIDER=alpaca
+
+# Alpaca Paper
 APCA_API_KEY_ID=
 APCA_API_SECRET_KEY=
 APCA_API_BASE_URL=https://paper-api.alpaca.markets
+
+# OANDA Practice
+OANDA_API_KEY=
+OANDA_ACCOUNT_ID=
+OANDA_API_BASE_URL=https://api-fxpractice.oanda.com
+
+# Binance Spot Testnet
+BINANCE_API_KEY=
+BINANCE_API_SECRET=
+BINANCE_API_BASE_URL=https://testnet.binance.vision
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment and secrets
 .env
+.env.bak
 .streamlit/secrets.toml
 
 # Bytecode

--- a/PaperTrader Lab/tests/test_credentials.py
+++ b/PaperTrader Lab/tests/test_credentials.py
@@ -1,43 +1,43 @@
 import importlib
 
 
+def test_env_merge_backup(tmp_path, monkeypatch):
+    monkeypatch.setenv("APP_ROOT", str(tmp_path))
+    secure_store = importlib.reload(importlib.import_module("utils.secure_store"))
+    config = importlib.reload(importlib.import_module("utils.config"))
+
+    (tmp_path / ".env").write_text("OTHER=1\n")
+    secure_store.save("alpaca", "env_file", "K1", "S1", "https://paper-api.alpaca.markets")
+    content = (tmp_path / ".env").read_text()
+    assert "OTHER=1" in content
+    assert (tmp_path / ".env.bak").exists()
+
+
 def test_migrate_env_to_keyring(tmp_path, monkeypatch):
     monkeypatch.setenv("APP_ROOT", str(tmp_path))
     secure_store = importlib.reload(importlib.import_module("utils.secure_store"))
     config = importlib.reload(importlib.import_module("utils.config"))
 
-    secure_store.write_to_env_file("K1", "S1", "https://paper-api.alpaca.markets")
-    creds = config.load_credentials()
+    secure_store.save("alpaca", "env_file", "K1", "S1", "https://paper-api.alpaca.markets")
+    creds = config.load_credentials("alpaca")
     assert creds["key"] == "K1"
-    assert config.current_storage_backend() == "env_file"
+    assert config.current_storage_backend("alpaca") == "env_file"
 
     store = {}
     monkeypatch.setattr(secure_store.keyring, "set_password", lambda s, u, p: store.__setitem__((s, u), p))
     monkeypatch.setattr(secure_store.keyring, "get_password", lambda s, u: store.get((s, u)))
-    monkeypatch.setattr(secure_store.keyring, "delete_password", lambda s, u: store.pop((s, u), None))
 
-    config.save_credentials("keyring", "K2", "S2", "https://paper-api.alpaca.markets")
-    secure_store.delete_env_file()
+    secure_store.save("alpaca", "keyring", "K2", "S2", "https://paper-api.alpaca.markets")
+    secure_store.delete("alpaca", "env_file")
 
-    creds2 = config.load_credentials()
+    creds2 = config.load_credentials("alpaca")
     assert creds2["key"] == "K2"
-    assert config.current_storage_backend() == "keyring"
+    assert config.current_storage_backend("alpaca") == "keyring"
 
 
-def test_test_alpaca_credentials(monkeypatch):
+def test_test_credentials(monkeypatch):
     import utils.config as config
 
-    class DummyClient:
-        def get_account(self):
-            return True
-
-    def fake_client(key, secret, paper=None, url_override=None):
-        assert key == "k" and secret == "s"
-        assert paper is True
-        assert url_override == "https://paper-api.alpaca.markets"
-        return DummyClient()
-
-    monkeypatch.setattr("alpaca.trading.client.TradingClient", fake_client)
-    ok, err = config.test_alpaca_credentials("k", "s", "https://paper-api.alpaca.markets")
+    ok, err = config.test_credentials("alpaca", "k", "s", "https://paper-api.alpaca.markets")
     assert ok and err == ""
 

--- a/PaperTrader Lab/utils/providers/__init__.py
+++ b/PaperTrader Lab/utils/providers/__init__.py
@@ -1,0 +1,14 @@
+"""Provider registry."""
+
+from .alpaca import AlpacaProvider
+from .oanda import OandaProvider
+from .binance import BinanceProvider
+
+PROVIDERS = {
+    "alpaca": AlpacaProvider(),
+    "oanda": OandaProvider(),
+    "binance": BinanceProvider(),
+}
+
+__all__ = ["PROVIDERS"]
+

--- a/PaperTrader Lab/utils/providers/alpaca.py
+++ b/PaperTrader Lab/utils/providers/alpaca.py
@@ -1,0 +1,18 @@
+"""Alpaca provider plugin."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .base import Provider
+
+
+class AlpacaProvider(Provider):
+    name = "alpaca"
+
+    def validate(self, creds: Dict[str, str]) -> None:  # pragma: no cover - trivial
+        super().validate(creds)
+
+
+__all__ = ["AlpacaProvider"]
+

--- a/PaperTrader Lab/utils/providers/base.py
+++ b/PaperTrader Lab/utils/providers/base.py
@@ -1,0 +1,26 @@
+"""Base provider interface."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class Provider:
+    """Simple provider plugin interface."""
+
+    name: str = ""
+
+    def get_required_fields(self) -> List[str]:
+        return ["key", "secret", "base_url"]
+
+    def validate(self, creds: Dict[str, str]) -> None:
+        """Raise an exception if credentials are invalid."""
+        if not creds.get("key") or not creds.get("secret"):
+            raise ValueError("missing credentials")
+
+    def build_client(self, creds: Dict[str, str]):  # pragma: no cover - placeholder
+        raise NotImplementedError
+
+
+__all__ = ["Provider"]
+

--- a/PaperTrader Lab/utils/providers/binance.py
+++ b/PaperTrader Lab/utils/providers/binance.py
@@ -1,0 +1,18 @@
+"""Binance provider plugin."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .base import Provider
+
+
+class BinanceProvider(Provider):
+    name = "binance"
+
+    def validate(self, creds: Dict[str, str]) -> None:  # pragma: no cover - trivial
+        super().validate(creds)
+
+
+__all__ = ["BinanceProvider"]
+

--- a/PaperTrader Lab/utils/providers/oanda.py
+++ b/PaperTrader Lab/utils/providers/oanda.py
@@ -1,0 +1,18 @@
+"""OANDA provider plugin."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .base import Provider
+
+
+class OandaProvider(Provider):
+    name = "oanda"
+
+    def validate(self, creds: Dict[str, str]) -> None:  # pragma: no cover - trivial
+        super().validate(creds)
+
+
+__all__ = ["OandaProvider"]
+

--- a/PaperTrader Lab/utils/secure_store.py
+++ b/PaperTrader Lab/utils/secure_store.py
@@ -1,4 +1,4 @@
-"""Utility per memorizzare le credenziali in modo sicuro e portabile."""
+"""Credential storage utilities for multiple providers with non-destructive `.env` merge."""
 
 from __future__ import annotations
 
@@ -8,36 +8,72 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import keyring
-from dotenv import dotenv_values, set_key
+from dotenv import dotenv_values
 
 try:  # tomllib is builtin on Python >=3.11
     import tomllib  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
     tomllib = None  # type: ignore
 
+
 PROJECT_ROOT = Path(os.getenv("APP_ROOT", Path(__file__).resolve().parents[2]))
 STREAMLIT_DIR = PROJECT_ROOT / ".streamlit"
 SECRETS_FILE = STREAMLIT_DIR / "secrets.toml"
 ENV_FILE = PROJECT_ROOT / ".env"
+ENV_BAK = PROJECT_ROOT / ".env.bak"
 
 
-def _creds_ok(creds: Dict[str, str]) -> bool:
-    return bool(creds.get("key") and creds.get("secret"))
+# Mapping provider -> env variable names & defaults
+PROVIDER_VARS: Dict[str, Dict[str, str]] = {
+    "alpaca": {
+        "key": "APCA_API_KEY_ID",
+        "secret": "APCA_API_SECRET_KEY",
+        "base_url": "APCA_API_BASE_URL",
+        "default_base_url": "https://paper-api.alpaca.markets",
+    },
+    "oanda": {
+        "key": "OANDA_API_KEY",
+        "secret": "OANDA_ACCOUNT_ID",
+        "base_url": "OANDA_API_BASE_URL",
+        "default_base_url": "https://api-fxpractice.oanda.com",
+    },
+    "binance": {
+        "key": "BINANCE_API_KEY",
+        "secret": "BINANCE_API_SECRET",
+        "base_url": "BINANCE_API_BASE_URL",
+        "default_base_url": "https://testnet.binance.vision",
+    },
+}
+
+
+_CURRENT_BACKEND: Dict[str, Optional[str]] = {}
+
+
+def _vars(provider: str) -> Dict[str, str]:
+    if provider not in PROVIDER_VARS:
+        raise ValueError(f"Unsupported provider {provider}")
+    return PROVIDER_VARS[provider]
 
 
 # ---------------------------------------------------------------------------
 # Loaders
 # ---------------------------------------------------------------------------
 
-def load_from_env() -> Optional[Dict[str, str]]:
-    key = os.getenv("APCA_API_KEY_ID")
-    secret = os.getenv("APCA_API_SECRET_KEY")
-    base = os.getenv("APCA_API_BASE_URL") or "https://paper-api.alpaca.markets"
+
+def _creds_ok(creds: Dict[str, str]) -> bool:
+    return bool(creds.get("key") and creds.get("secret"))
+
+
+def _load_from_env(provider: str) -> Optional[Dict[str, str]]:
+    names = _vars(provider)
+    key = os.getenv(names["key"])
+    secret = os.getenv(names["secret"])
+    base = os.getenv(names["base_url"]) or names["default_base_url"]
     creds = {"key": key, "secret": secret, "base_url": base}
     return creds if _creds_ok(creds) else None
 
 
-def load_from_secrets() -> Optional[Dict[str, str]]:
+def _load_from_secrets(provider: str) -> Optional[Dict[str, str]]:
     if not SECRETS_FILE.exists() or tomllib is None:
         return None
     try:
@@ -45,16 +81,17 @@ def load_from_secrets() -> Optional[Dict[str, str]]:
             data = tomllib.load(fh)
     except Exception:
         return None
-    key = data.get("APCA_API_KEY_ID")
-    secret = data.get("APCA_API_SECRET_KEY")
-    base = data.get("APCA_API_BASE_URL") or "https://paper-api.alpaca.markets"
+    names = _vars(provider)
+    key = data.get(names["key"])
+    secret = data.get(names["secret"])
+    base = data.get(names["base_url"]) or names["default_base_url"]
     creds = {"key": key, "secret": secret, "base_url": base}
     return creds if _creds_ok(creds) else None
 
 
-def load_from_keyring() -> Optional[Dict[str, str]]:
+def _load_from_keyring(provider: str) -> Optional[Dict[str, str]]:
     try:
-        raw = keyring.get_password("alpaca", "default")
+        raw = keyring.get_password(provider, "default")
     except Exception:
         return None
     if not raw:
@@ -63,83 +100,146 @@ def load_from_keyring() -> Optional[Dict[str, str]]:
         data = json.loads(raw)
     except Exception:
         return None
+    names = _vars(provider)
     key = data.get("key")
     secret = data.get("secret")
-    base = data.get("base_url") or "https://paper-api.alpaca.markets"
+    base = data.get("base_url") or names["default_base_url"]
     creds = {"key": key, "secret": secret, "base_url": base}
     return creds if _creds_ok(creds) else None
 
 
-def load_from_env_file() -> Optional[Dict[str, str]]:
+def _load_from_env_file(provider: str) -> Optional[Dict[str, str]]:
     if not ENV_FILE.exists():
         return None
     data = dotenv_values(ENV_FILE)
-    key = data.get("APCA_API_KEY_ID")
-    secret = data.get("APCA_API_SECRET_KEY")
-    base = data.get("APCA_API_BASE_URL") or "https://paper-api.alpaca.markets"
+    names = _vars(provider)
+    key = data.get(names["key"])
+    secret = data.get(names["secret"])
+    base = data.get(names["base_url"]) or names["default_base_url"]
     creds = {"key": key, "secret": secret, "base_url": base}
     return creds if _creds_ok(creds) else None
+
+
+def load(provider: str) -> Dict[str, str]:
+    for backend, loader in [
+        ("env", _load_from_env),
+        ("secrets", _load_from_secrets),
+        ("keyring", _load_from_keyring),
+        ("env_file", _load_from_env_file),
+    ]:
+        creds = loader(provider)
+        if creds:
+            _CURRENT_BACKEND[provider] = backend
+            return creds
+    _CURRENT_BACKEND[provider] = None
+    names = _vars(provider)
+    return {"key": "", "secret": "", "base_url": names["default_base_url"]}
+
+
+def current_storage_backend(provider: str) -> Optional[str]:
+    return _CURRENT_BACKEND.get(provider)
 
 
 # ---------------------------------------------------------------------------
 # Writers
 # ---------------------------------------------------------------------------
 
-def write_to_secrets(key: str, secret: str, base_url: str) -> None:
-    STREAMLIT_DIR.mkdir(parents=True, exist_ok=True)
-    data = {
-        "APCA_API_KEY_ID": key,
-        "APCA_API_SECRET_KEY": secret,
-        "APCA_API_BASE_URL": base_url,
-    }
-    with open(SECRETS_FILE, "w", encoding="utf-8") as fh:
-        for k, v in data.items():
-            fh.write(f"{k}='{v}'\n")
+
+def _write_env_file(data: Dict[str, str]) -> None:
+    existing: Dict[str, str] = {}
+    if ENV_FILE.exists():
+        ENV_BAK.write_text(ENV_FILE.read_text())
+        existing = dotenv_values(ENV_FILE)
+    existing.update(data)
+    with open(ENV_FILE, "w", encoding="utf-8") as fh:
+        for k, v in existing.items():
+            if v is None:
+                continue
+            fh.write(f"{k}={v}\n")
 
 
-def write_to_keyring(key: str, secret: str, base_url: str) -> None:
-    payload = json.dumps({"key": key, "secret": secret, "base_url": base_url})
-    keyring.set_password("alpaca", "default", payload)
-
-
-def write_to_env_file(key: str, secret: str, base_url: str) -> None:
-    ENV_FILE.touch(exist_ok=True)
-    set_key(ENV_FILE, "APCA_API_KEY_ID", key)
-    set_key(ENV_FILE, "APCA_API_SECRET_KEY", secret)
-    set_key(ENV_FILE, "APCA_API_BASE_URL", base_url)
+def save(provider: str, target: str, key: str, secret: str, base_url: str) -> None:
+    names = _vars(provider)
+    if target == "secrets":
+        STREAMLIT_DIR.mkdir(parents=True, exist_ok=True)
+        data = {}
+        if SECRETS_FILE.exists() and tomllib is not None:
+            try:
+                with open(SECRETS_FILE, "rb") as fh:
+                    data = tomllib.load(fh)
+            except Exception:
+                data = {}
+        data.update(
+            {
+                names["key"]: key,
+                names["secret"]: secret,
+                names["base_url"]: base_url,
+            }
+        )
+        with open(SECRETS_FILE, "w", encoding="utf-8") as fh:
+            for k, v in data.items():
+                fh.write(f"{k}='{v}'\n")
+    elif target == "keyring":
+        payload = json.dumps({"key": key, "secret": secret, "base_url": base_url})
+        keyring.set_password(provider, "default", payload)
+    elif target == "env_file":
+        _write_env_file(
+            {names["key"]: key, names["secret"]: secret, names["base_url"]: base_url}
+        )
+    else:
+        raise ValueError(f"Unsupported target {target}")
 
 
 # ---------------------------------------------------------------------------
 # Deleters
 # ---------------------------------------------------------------------------
 
-def delete_secrets() -> None:
-    if SECRETS_FILE.exists():
-        SECRETS_FILE.unlink()
 
-
-def delete_keyring() -> None:
-    try:
-        keyring.delete_password("alpaca", "default")
-    except Exception:
-        pass
-
-
-def delete_env_file() -> None:
-    if ENV_FILE.exists():
-        ENV_FILE.unlink()
+def delete(provider: str, target: str) -> None:
+    names = _vars(provider)
+    if target == "secrets":
+        if not SECRETS_FILE.exists() or tomllib is None:
+            return
+        try:
+            with open(SECRETS_FILE, "rb") as fh:
+                data = tomllib.load(fh)
+        except Exception:
+            return
+        changed = False
+        for k in (names["key"], names["secret"], names["base_url"]):
+            if k in data:
+                data.pop(k)
+                changed = True
+        if changed:
+            with open(SECRETS_FILE, "w", encoding="utf-8") as fh:
+                for k, v in data.items():
+                    fh.write(f"{k}='{v}'\n")
+    elif target == "keyring":
+        try:
+            keyring.delete_password(provider, "default")
+        except Exception:
+            pass
+    elif target == "env_file":
+        if not ENV_FILE.exists():
+            return
+        ENV_BAK.write_text(ENV_FILE.read_text())
+        data = dotenv_values(ENV_FILE)
+        for k in (names["key"], names["secret"], names["base_url"]):
+            data.pop(k, None)
+        with open(ENV_FILE, "w", encoding="utf-8") as fh:
+            for k, v in data.items():
+                if v is None:
+                    continue
+                fh.write(f"{k}={v}\n")
+    else:
+        raise ValueError(f"Unsupported target {target}")
 
 
 __all__ = [
-    "load_from_env",
-    "load_from_secrets",
-    "load_from_keyring",
-    "load_from_env_file",
-    "write_to_secrets",
-    "write_to_keyring",
-    "write_to_env_file",
-    "delete_secrets",
-    "delete_keyring",
-    "delete_env_file",
+    "load",
+    "save",
+    "delete",
+    "current_storage_backend",
+    "PROVIDER_VARS",
 ]
 

--- a/README.md
+++ b/README.md
@@ -30,28 +30,45 @@
 
 ---
 
-## 🔑 Configurazione credenziali
+## 🔐 Credenziali & Deploy
 
-Al primo avvio l'applicazione mostra un **Setup Wizard** per inserire le credenziali *Alpaca Paper*.
+L'app supporta più provider con un **wizard di primo login** e un pannello "Impostazioni" per ruotare/migrare le chiavi.
 
-1. Inserisci **API Key** e **Secret** (quest'ultima è mascherata).
-2. Scegli dove salvarle:
-   - **Keychain** (consigliato, usa `keyring` del sistema operativo)
-   - `secrets.toml` (`.streamlit/secrets.toml`)
-   - file `.env`
-3. Premi **Salva & Test** → le chiavi vengono memorizzate, ricaricate e verificate con una chiamata di prova.
+Provider attivi di default:
 
-Ordine di precedenza al caricamento:
-1. Variabili d'ambiente (`APCA_API_KEY_ID`, `APCA_API_SECRET_KEY`, `APCA_API_BASE_URL`)
+- **Alpaca Paper** – trading demo su azioni USA
+- **OANDA Practice** – forex demo
+- **Binance Spot Testnet** – crypto demo
+
+### Ordine di precedenza
+
+1. Variabili d'ambiente
 2. `st.secrets` (`.streamlit/secrets.toml`)
-3. Keychain (`keyring`, servizio `alpaca`, utente `default`)
+3. Keyring del sistema operativo
 4. File `.env`
 
-Le chiavi **non** vengono mai salvate nel repository Git. Per distribuire l'app in ambienti gestiti (es. Streamlit Cloud) usa `st.secrets`; in locale preferisci il Keychain oppure `.env` (ignorato da Git).
+I salvataggi sono **non distruttivi**: quando si scrive su `.env` viene creato un backup `.env.bak` e le chiavi esistenti vengono mantenute.
 
-Esempio di `.env`:
+### Backend di storage
+
+| Backend        | Vantaggi                              | Svantaggi |
+|---------------|---------------------------------------|-----------|
+| Keyring       | Sicuro, consigliato per uso locale    | Dipende dal sistema operativo |
+| `st.secrets`  | Comodo in deploy (Streamlit Cloud)    | File non cifrato su disco |
+| `.env`        | Semplice per sviluppo locale          | Non cifrato, va escluso da Git |
+
+`.env` e `.streamlit/secrets.toml` sono già ignorati da Git; usa `.env.example` come riferimento.
+
+### Setup rapido
+
+1. Avvia l'app e segui il wizard: scegli provider → inserisci API Key/Secret/Base URL → scegli backend → **Salva & Test**.
+2. Nella tab "Impostazioni" puoi verificare lo stato (icone ✅/⚠️/❌), mostrare i secret mascherati, ruotare o cancellare le chiavi.
+3. Per migrare le chiavi tra backend, usa il wizard scegliendo una destinazione diversa; lo `.env` originale viene mantenuto con backup.
+
+Esempio `.env` generato:
 
 ```bash
+ENABLE_ALPACA=true
 APCA_API_KEY_ID=pk_xxxxxxxxxxxxxxxx
 APCA_API_SECRET_KEY=sk_xxxxxxxxxxxxxxxx
 APCA_API_BASE_URL=https://paper-api.alpaca.markets


### PR DESCRIPTION
## Summary
- implement provider-aware secure credential storage with non-destructive .env merge
- add Pydantic settings and provider plugins for Alpaca, OANDA and Binance
- refresh Streamlit UI with multi-step credential wizard and settings panel

## Testing
- `python -m pip install -r 'PaperTrader Lab/requirements.txt' python-dotenv keyring pydantic pytest`
- `python -m pip install pydantic-settings`
- `PYTHONPATH='PaperTrader Lab' pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d56e71d4832d81079422da0593f8