### PR TITLE
Add provider credential validation and error propagation

### DIFF
--- a/PaperTrader Lab/tests/conftest.py
+++ b/PaperTrader Lab/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))

--- a/PaperTrader Lab/tests/test_credentials.py
+++ b/PaperTrader Lab/tests/test_credentials.py
@@ -36,7 +36,13 @@ def test_migrate_env_to_keyring(tmp_path, monkeypatch):
 
 
 def test_test_credentials(monkeypatch):
+    import httpx
     import utils.config as config
+
+    def fake_get(url, headers=None, timeout=None):
+        return httpx.Response(200, request=httpx.Request("GET", url), text="ok")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
 
     ok, err = config.test_credentials("alpaca", "k", "s", "https://paper-api.alpaca.markets")
     assert ok and err == ""

--- a/PaperTrader Lab/tests/test_provider_validation.py
+++ b/PaperTrader Lab/tests/test_provider_validation.py
@@ -1,0 +1,33 @@
+import httpx
+import pytest
+
+from utils.config import test_credentials as _test_credentials
+
+
+@pytest.mark.parametrize("provider", ["alpaca", "oanda", "binance"])
+def test_validate_success(monkeypatch, provider):
+    def fake_get(url, headers=None, timeout=None):
+        return httpx.Response(200, request=httpx.Request("GET", url), text="ok")
+    monkeypatch.setattr(httpx, "get", fake_get)
+    ok, err = _test_credentials(provider, "k", "s", "https://api.test")
+    assert ok and err == ""
+
+
+@pytest.mark.parametrize("provider", ["alpaca", "oanda", "binance"])
+def test_validate_invalid(monkeypatch, provider):
+    def fake_get(url, headers=None, timeout=None):
+        return httpx.Response(401, request=httpx.Request("GET", url), text="bad creds")
+    monkeypatch.setattr(httpx, "get", fake_get)
+    ok, err = _test_credentials(provider, "k", "s", "https://api.test")
+    assert not ok
+    assert "bad creds" in err
+
+
+@pytest.mark.parametrize("provider", ["alpaca", "oanda", "binance"])
+def test_validate_network_failure(monkeypatch, provider):
+    def fake_get(url, headers=None, timeout=None):
+        raise httpx.ConnectError("boom", request=httpx.Request("GET", url))
+    monkeypatch.setattr(httpx, "get", fake_get)
+    ok, err = _test_credentials(provider, "k", "s", "https://api.test")
+    assert not ok
+    assert "boom" in err

--- a/PaperTrader Lab/utils/config.py
+++ b/PaperTrader Lab/utils/config.py
@@ -45,7 +45,11 @@ def test_credentials(provider: str, key: str, secret: str, base_url: str) -> Tup
         PROVIDERS[provider].validate({"key": key, "secret": secret, "base_url": base_url})
         return True, ""
     except Exception as e:  # pragma: no cover - network or plugin errors
-        return False, str(e)
+        msg = str(e)
+        cause = getattr(e, "__cause__", None)
+        if cause:
+            msg = f"{msg} (caused by {cause})"
+        return False, msg
 
 
 def _as_bool(x: str, default: bool = False) -> bool:

--- a/PaperTrader Lab/utils/providers/alpaca.py
+++ b/PaperTrader Lab/utils/providers/alpaca.py
@@ -4,14 +4,28 @@ from __future__ import annotations
 
 from typing import Dict
 
+import httpx
+
 from .base import Provider
 
 
 class AlpacaProvider(Provider):
     name = "alpaca"
 
-    def validate(self, creds: Dict[str, str]) -> None:  # pragma: no cover - trivial
+    def validate(self, creds: Dict[str, str]) -> None:
         super().validate(creds)
+        url = f"{creds['base_url'].rstrip('/')}/v2/account"
+        headers = {
+            "APCA-API-KEY-ID": creds["key"],
+            "APCA-API-SECRET-KEY": creds["secret"],
+        }
+        try:
+            resp = httpx.get(url, headers=headers, timeout=5)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
+            raise ValueError(f"{e.response.status_code} {e.response.text}") from e
+        except httpx.HTTPError as e:  # pragma: no cover - network errors
+            raise ValueError(f"network error: {e}") from e
 
 
 __all__ = ["AlpacaProvider"]

--- a/PaperTrader Lab/utils/providers/binance.py
+++ b/PaperTrader Lab/utils/providers/binance.py
@@ -4,14 +4,31 @@ from __future__ import annotations
 
 from typing import Dict
 
+import hashlib
+import hmac
+import time
+import httpx
+
 from .base import Provider
 
 
 class BinanceProvider(Provider):
     name = "binance"
 
-    def validate(self, creds: Dict[str, str]) -> None:  # pragma: no cover - trivial
+    def validate(self, creds: Dict[str, str]) -> None:
         super().validate(creds)
+        timestamp = int(time.time() * 1000)
+        query = f"timestamp={timestamp}"
+        signature = hmac.new(creds["secret"].encode(), query.encode(), hashlib.sha256).hexdigest()
+        url = f"{creds['base_url'].rstrip('/')}/api/v3/account?{query}&signature={signature}"
+        headers = {"X-MBX-APIKEY": creds["key"]}
+        try:
+            resp = httpx.get(url, headers=headers, timeout=5)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
+            raise ValueError(f"{e.response.status_code} {e.response.text}") from e
+        except httpx.HTTPError as e:  # pragma: no cover - network errors
+            raise ValueError(f"network error: {e}") from e
 
 
 __all__ = ["BinanceProvider"]

--- a/PaperTrader Lab/utils/providers/oanda.py
+++ b/PaperTrader Lab/utils/providers/oanda.py
@@ -4,14 +4,25 @@ from __future__ import annotations
 
 from typing import Dict
 
+import httpx
+
 from .base import Provider
 
 
 class OandaProvider(Provider):
     name = "oanda"
 
-    def validate(self, creds: Dict[str, str]) -> None:  # pragma: no cover - trivial
+    def validate(self, creds: Dict[str, str]) -> None:
         super().validate(creds)
+        url = f"{creds['base_url'].rstrip('/')}/v3/accounts"
+        headers = {"Authorization": f"Bearer {creds['key']}"}
+        try:
+            resp = httpx.get(url, headers=headers, timeout=5)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
+            raise ValueError(f"{e.response.status_code} {e.response.text}") from e
+        except httpx.HTTPError as e:  # pragma: no cover - network errors
+            raise ValueError(f"network error: {e}") from e
 
 
 __all__ = ["OandaProvider"]


### PR DESCRIPTION
## Summary
- Verify Alpaca, Binance, and OANDA credentials via lightweight authenticated API calls
- Surface detailed provider errors through `config.test_credentials`
- Add extensive tests for credential validation success, invalid creds, and network failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5dcc4b328832db53ce0698de4b8f4